### PR TITLE
Fixed (worked around?) `git build` error on go.mod: "go.mod:3: invalid go version '1.22.6': must match format 1.23"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/marcopaganini/rcalc
 
-go 1.22.6
+go 1.22
 
 require github.com/chzyer/readline v1.5.1
 


### PR DESCRIPTION
As per the title.