### PR TITLE
Command print full stack, worked around `go build` error, fixed typo on Subtracy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/marcopaganini/rcalc
 
-go 1.22.6
+go 1.22
 
 require github.com/chzyer/readline v1.5.1
 

--- a/main.go
+++ b/main.go
@@ -145,7 +145,7 @@ func main() {
 	ops := map[string]ophandler{
 		// Basic operations
 		"+": {"Add x to y", 2, false, func(a []float64) (float64, error) { return a[0] + a[1], nil }},
-		"-": {"Subtracy x from y", 2, false, func(a []float64) (float64, error) { return a[0] - a[1], nil }},
+		"-": {"Subtract x from y", 2, false, func(a []float64) (float64, error) { return a[0] - a[1], nil }},
 		"*": {"Multiply x and y", 2, false, func(a []float64) (float64, error) { return a[0] * a[1], nil }},
 		"/": {"Divide y by x", 2, false, func(a []float64) (float64, error) {
 			if a[1] == 0 {

--- a/main.go
+++ b/main.go
@@ -163,6 +163,7 @@ func main() {
 		"s": {"Display stack", 0, true, func(_ []float64) (float64, error) { stack.print(); return 0, nil }},
 		"c": {"Clear stack", 0, true, func(_ []float64) (float64, error) { stack.clear(); return 0, nil }},
 		"=": {"Print top of stack (x)", 0, true, func(_ []float64) (float64, error) { fmt.Println(stack.top()); return 0, nil }},
+		"p": {"Print full stack", 0, true, func(_ []float64) (float64, error) { stack.print(); return 0, nil }},
 
 		// program control
 		"debug": {"Toggle debugging", 0, true, func(_ []float64) (float64, error) {


### PR DESCRIPTION
Accumulated PR with previous other two; this one implements a new command, "p" to print the full stack