### PR TITLE
Process command-line arguments as an expression

### DIFF
--- a/main.go
+++ b/main.go
@@ -157,7 +157,11 @@ func calc(stack *stackType, cmd string) error {
 		}
 
 		if autoprint {
-			stack.printTop(ops.base, single)
+			if single {
+				fmt.Println(stack.top()) // plain print to stdout
+			} else {
+				stack.printTop(ops.base) // pretty print to terminal
+			}
 		}
 
 		// Break after the first iteration if a command is passed.

--- a/main.go
+++ b/main.go
@@ -171,13 +171,7 @@ func calc(stack *stackType, cmd string) error {
 func main() {
 	stack := &stackType{}
 
-	// treat the cmdline arguments as an expression to be processed
-	expr := ""
-	for _, arg := range os.Args[1:] {
-		expr += arg + " "
-	}
-
-	if err := calc(stack, expr); err != nil {
+	if err := calc(stack, strings.Join(os.Args[1:], " ")); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -156,12 +156,13 @@ func calc(stack *stackType, cmd string) error {
 			continue
 		}
 
+		if autoprint {
+			stack.printTop(ops.base, single)
+		}
+
 		// Break after the first iteration if a command is passed.
 		if single {
 			break
-		}
-		if autoprint {
-			stack.printTop(ops.base)
 		}
 	}
 	return nil
@@ -169,7 +170,14 @@ func calc(stack *stackType, cmd string) error {
 
 func main() {
 	stack := &stackType{}
-	if err := calc(stack, ""); err != nil {
+
+	// treat the cmdline arguments as an expression to be processed
+	expr := ""
+	for _, arg := range os.Args[1:] {
+		expr += arg + " "
+	}
+
+	if err := calc(stack, expr); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/stack.go
+++ b/stack.go
@@ -51,8 +51,17 @@ func (x *stackType) top() float64 {
 }
 
 // printTop displays the top of the stack using the base indicated.
-func (x *stackType) printTop(base int) {
-	color.Cyan("= %s", formatNumber(x.top(), base))
+func (x *stackType) printTop(base int, args ...bool) {
+	plain := false
+	top := formatNumber(x.top(), base)
+	if len(args) > 0 {
+		plain = args[0]
+	}
+	if plain {
+		println(top)
+	} else {
+		color.Cyan("= %s", top)
+	}
 }
 
 // print displays the contents of the stack using the base indicated.

--- a/stack.go
+++ b/stack.go
@@ -51,17 +51,8 @@ func (x *stackType) top() float64 {
 }
 
 // printTop displays the top of the stack using the base indicated.
-func (x *stackType) printTop(base int, args ...bool) {
-	plain := false
-	top := formatNumber(x.top(), base)
-	if len(args) > 0 {
-		plain = args[0]
-	}
-	if plain {
-		println(top)
-	} else {
-		color.Cyan("= %s", top)
-	}
+func (x *stackType) printTop(base int) {
+	color.Cyan("= %s", formatNumber(x.top(), base))
 }
 
 // print displays the contents of the stack using the base indicated.


### PR DESCRIPTION
Exempli Gratia: 
```
$ ./rpn 
> 1 1 + 
= 2
> q
Bye.
$ ./rpn 1 1 + 
2
$ 
```
Notice the result of evaluating the command-line is printed without any formatting (no "= " prefix, no colors, etc) just so it can be used straight out by other programs/scripts, just as an RPN brother to `expr`. 