### PR TITLE
Don´t print humanized format in single-command mode.

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -86,7 +86,7 @@ func stripTrailingDigits(s string, digits int) string {
 
 // formatNumber formats the number using base and decimals. For bases different
 // than 10, non-integer floating numbers are truncated.
-func formatNumber(ctx decimal.Context, n *decimal.Big, base, decimals int) string {
+func formatNumber(ctx decimal.Context, n *decimal.Big, base, decimals int, single bool) string {
 	// Print NaN without suffix numbers.
 	if n.IsNaN(0) {
 		return strings.TrimRight(fmt.Sprint(n), "0123456789")
@@ -134,8 +134,8 @@ func formatNumber(ctx decimal.Context, n *decimal.Big, base, decimals int) strin
 		buf.WriteString(fmt.Sprintf("0x%x%s", n64, suffix))
 	default:
 		h := commafWithDigits(n, decimals)
-		// Only print humanized format when it differs from original value.
-		if h != clean {
+		// Only print humanized format when it differs from original value, and not in single-command mode
+		if h != clean && !single {
 			suffix = " (" + h + ")"
 		}
 		buf.WriteString(clean + suffix)

--- a/decimal.go
+++ b/decimal.go
@@ -31,7 +31,10 @@ func bigFloat(s string) *decimal.Big {
 
 // commafWithDigits idea comes from the humanize library, but was modified to
 // work with decimal numbers.
-func commafWithDigits(v *decimal.Big, decimals int) string {
+func commafWithDigits(n *decimal.Big, decimals int) string {
+	// Make a copy so we won't modify the original value (passed by pointer).
+	v := big().Copy(n)
+
 	buf := &bytes.Buffer{}
 	if v.Sign() < 0 {
 		buf.Write([]byte{'-'})

--- a/main.go
+++ b/main.go
@@ -200,7 +200,7 @@ func calc(stack *stackType, cmd string) error {
 
 		if autoprint {
 			if single {
-				fmt.Println(stack.top()) // plain print to stdout
+				fmt.Println(formatNumber(ctx, stack.top(), ops.base, ops.decimals, true)) // plain print to stdout
 			} else {
 				stack.printTop(ctx, ops.base, ops.decimals) // pretty print to terminal
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -240,7 +240,7 @@ func TestFormatNumber(t *testing.T) {
 		{16, big().Add(bigUint(0xff), bigFloat("0.5")).SetSignbit(true), "-0xff (truncated from -255.5)"},
 	}
 	for _, tt := range casetests {
-		got := formatNumber(ctx, tt.input, tt.base, 6)
+		got := formatNumber(ctx, tt.input, tt.base, 6, false)
 		if got != tt.want {
 			t.Fatalf("diff: base: %d, input: %v, want: %q, got: %q", tt.base, tt.input, tt.want, got)
 		}

--- a/stack.go
+++ b/stack.go
@@ -51,7 +51,7 @@ func (x *stackType) top() *decimal.Big {
 
 // printTop displays the top of the stack using the base indicated.
 func (x *stackType) printTop(ctx decimal.Context, base, decimals int) {
-	color.Cyan("= %s", formatNumber(ctx, x.top(), base, decimals))
+	color.Cyan("= %s", formatNumber(ctx, x.top(), base, decimals, false))
 }
 
 // print displays the contents of the stack using the base indicated.
@@ -67,6 +67,6 @@ func (x *stackType) print(ctx decimal.Context, base, decimals int) {
 		case last - 1:
 			tag = " y"
 		}
-		fmt.Printf("%s: %s\n", tag, formatNumber(ctx, x.list[ix], base, decimals))
+		fmt.Printf("%s: %s\n", tag, formatNumber(ctx, x.list[ix], base, decimals, false))
 	}
 }


### PR DESCRIPTION
Instead of doing that: 

`$ rpn 10 fmt 567 999 `
![image](https://github.com/user-attachments/assets/25c0bedf-c8ea-42a2-8c8e-e73221d85614)

wit this fix, it does this: 

`$ ./rpn 10 fmt 567 999 /`
0.5675675676

(ie, no '=  ' at the start of the output, and no colors either, so it's ready for use in scripts, etc).